### PR TITLE
fix: Reset store on user logout

### DIFF
--- a/web/src/features/redux/users/userSlice.js
+++ b/web/src/features/redux/users/userSlice.js
@@ -33,6 +33,7 @@ export const usersSlice = createSlice({
         last_name: "",
         store_name: "",
         role: "",
+        store: {},
       };
     },
     set_user_store: (state, action) => {


### PR DESCRIPTION
### Issue
- Closes #15 

### Feature
- resolve issue where user logout would retain store information